### PR TITLE
fix: return day in day() method not weekday

### DIFF
--- a/src/kurdishDate.ts
+++ b/src/kurdishDate.ts
@@ -125,7 +125,7 @@ export default class KurdishDate {
     }
 
     public day(): number {
-        return this.calendar().weekday;
+        return this.calendar().day;
     }
 
     public date(date?: number): number {


### PR DESCRIPTION
When I was using the day method i encountered a problem, it was returning the weekday not the day in the month number. If this is intentional i suggest creating another method to get the weekday called weekday